### PR TITLE
run dev & start in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "dev": "webpack",
-    "start": "electron ."
+    "serve": "electron .",
+    "start": "npm-run-all --parallel dev serve"
   },
   "author": "J. Renato Ramos González <renato.etc.etc.etc@gmail.com>",
   "repository": "pastahito/electron-react-webpack",
@@ -19,7 +20,8 @@
     "electron-reload": "^1.1.0",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",
-    "webpack": "^2.2.1"
+    "webpack": "^2.2.1",
+    "npm-run-all": "^4.1.2"
   },
   "dependencies": {
     "react": "^15.4.2",


### PR DESCRIPTION
This PR makes it so you can just run `npm start` and it runs webpack & electron in parallel.