### PR TITLE
semantic-ui-react and semantic-ui-css support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "electron-reload": "^1.1.0",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "file-loader": "^0.9.0",
+    "semantic-ui-css": "^2.2.14",
+    "semantic-ui-react": "^0.78.2",
+    "style-loader": "^0.20.1",
+    "url-loader": "^0.6.2",
     "webpack": "^2.2.1"
   },
   "dependencies": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,51 +1,60 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
 module.exports = {
+  watch: true,
 
-    watch: true,
+  target: "electron",
 
-    target: 'electron',
+  entry: "./app/src/entry.js",
 
-    entry: './app/src/entry.js',
+  output: {
+    path: __dirname + "/app/build",
+    publicPath: "build/",
+    filename: "bundle.js"
+  },
 
-    output: {
-        path: __dirname + '/app/build',
-        publicPath: 'build/',
-        filename: 'bundle.js'
-    },
-
-    module: {
-        rules: [
-            {
-                test: /\.jsx?$/,
-                loader: 'babel-loader',
-                options: {
-                    presets: ['react']
-                }
-            },
-            {
-                test: /\.css$/,
-                loader: ExtractTextPlugin.extract({
-                    loader: 'css-loader'
-                })
-            },
-            {
-                test: /\.(png|jpg|gif|svg)$/,
-                loader: 'file-loader',
-                query: {
-                    name: '[name].[ext]?[hash]'
-                }
-            }
-        ]
-    },
-
-    plugins: [
-        new ExtractTextPlugin({
-            filename: 'bundle.css',
-            disable: false,
-            allChunks: true
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        options: {
+          presets: ["react"]
         }
-    )
-]
+      },
+      {
+        test: /\.css$/,
+        loader: ExtractTextPlugin.extract({
+          fallback: "style-loader",
+          use: [
+            {
+              loader: "css-loader"
+            },
+            {
+              loader: "postcss-loader"
+            }
+          ]
+        })
+      },
+      {
+        test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+        loader: "url-loader?limit=100000"
+      },
+      {
+        test: /\.(png|jpg|gif|svg)$/,
+        loader: "file-loader",
+        query: {
+          name: "[name].[ext]?[hash]"
+        }
+      }
+    ]
+  },
 
-}
+  plugins: [
+    new ExtractTextPlugin({
+      filename: "bundle.css",
+      disable: false,
+      allChunks: true
+    })
+  ]
+};


### PR DESCRIPTION
This pull request is related to the webpack configuration support of `semantic-ui-react` and `semantic-ui-css` for React. Actually, the same configurations I have used in one of my [project](https://github.com/lalitmee/simple-electron-react) **simple react and electron application.** I struggled a lot to get this work for my project. That's why I wanted to help so that others can do it easily.